### PR TITLE
Account creation

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,9 +4,10 @@ class Api::V1::UsersController < ApplicationController
     if user.save
       render json: UserSerializer.new(User.all)
     else
-      rescue_from ActionController::ParameterMissing do
-        render :nothing => true, :status => :bad_request
-      end
+      render json: {
+        error: "Invalid request. Please try again.",
+        status: 400
+      }, status: 400
     end
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -2,7 +2,10 @@ class Api::V1::UsersController < ApplicationController
   def create
     user = User.create(user_params)
     if user.save
-      render json: UserSerializer.new(User.all)
+      render json: {
+        "api_key": "jgn983hy48thw9begh98h4539h4",
+        status: 201
+      }, status: 201
     else
       render json: {
         error: "Invalid request. Please try again.",

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,18 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    user = User.create(user_params)
+    if user.save
+      render json: UserSerializer.new(User.all)
+    else
+      rescue_from ActionController::ParameterMissing do
+        render :nothing => true, :status => :bad_request
+      end
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:email, :password, :password_confirmation)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,9 @@
+class User < ApplicationRecord
+  has_secure_password
+
+  validates :email, presence: true,
+    format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i },
+    uniqueness: { case_sensitive: false }
+
+  validates :password, confirmation: true
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,0 @@
-class UserSerializer
-  include FastJsonapi::ObjectSerializer
-  attributes :id, :email, :password, :password_confirmation
-end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :email, :password, :password_confirmation
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get '/forecast', to: "forecast#index"
       get '/backgrounds', to: "background#show"
+      post '/users', to: "users#create"
     end
   end
 end

--- a/db/migrate/20191104225354_create_users.rb
+++ b/db/migrate/20191104225354_create_users.rb
@@ -1,0 +1,8 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2019_11_04_225354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+  end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe User, type: :model do
+  describe "validations" do
+    it {should validate_presence_of :email}
+    it {should validate_uniqueness_of(:email).case_insensitive}
+    it {should allow_value('user@example.com').for(:email)}
+    it {should_not allow_value("foo").for(:email)}
+    it {should validate_presence_of :password}
+    it {should validate_confirmation_of(:password).on(:create)}
+  end
+end

--- a/spec/requests/api/v1/user_spec.rb
+++ b/spec/requests/api/v1/user_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Account Creation' do
+  let(:user_attributes) { { email: 'whatever@example.com', password: 'password', password_confirmation: 'password' } }
+
+  it 'creates new user account' do
+
+    post '/api/v1/users', params: user_attributes
+
+    expect(response).to be_successful
+
+    parsed = JSON.parse(response.body, symbolize_names: true)
+
+    expect(parsed[:data].first[:attributes].count).to eq(4)
+    expect(parsed[:data].first[:attributes]).to have_key(:email)
+    expect(parsed[:data].first[:attributes]).to have_key(:password)
+    expect(parsed[:data].first[:attributes]).to have_key(:password_confirmation)
+  end
+end

--- a/spec/requests/api/v1/user_spec.rb
+++ b/spec/requests/api/v1/user_spec.rb
@@ -11,10 +11,8 @@ describe 'Account Creation' do
 
     parsed = JSON.parse(response.body, symbolize_names: true)
 
-    expect(parsed[:data].first[:attributes].count).to eq(4)
-    expect(parsed[:data].first[:attributes]).to have_key(:email)
-    expect(parsed[:data].first[:attributes]).to have_key(:password)
-    expect(parsed[:data].first[:attributes]).to have_key(:password_confirmation)
+    expect(parsed).to have_key(:api_key)
+    expect(parsed[:api_key]).to eq('jgn983hy48thw9begh98h4539h4')
   end
 
   it 'returns 400 status code when given an invalid request' do

--- a/spec/requests/api/v1/user_spec.rb
+++ b/spec/requests/api/v1/user_spec.rb
@@ -16,4 +16,14 @@ describe 'Account Creation' do
     expect(parsed[:data].first[:attributes]).to have_key(:password)
     expect(parsed[:data].first[:attributes]).to have_key(:password_confirmation)
   end
+
+  it 'returns 400 status code when given an invalid request' do
+    post '/api/v1/users', params: {}
+
+    expect(response.status).to eq(400)
+
+    parsed = JSON.parse(response.body, symbolize_names: true)
+    expect(parsed).to have_key(:error)
+    expect(parsed[:error]).to eq('Invalid request. Please try again.')
+  end
 end


### PR DESCRIPTION
This PR adds the following:
- a post endpoint for new account creation
```
post /api/v1/users
```
- Add a namespaced UsersController
- Add a migration for `User` model
- Add custom json response for both valid and invalid requests