### PR TITLE
Add to forecast

### DIFF
--- a/app/models/forecast.rb
+++ b/app/models/forecast.rb
@@ -12,7 +12,9 @@ class Forecast
               :visibility,
               :uvIndex,
               :summaries,
-              :time
+              :time,
+              :hourly_forecast,
+              :daily_forecast
 
   def initialize(location, weather_data)
     @id = 0
@@ -29,6 +31,8 @@ class Forecast
     @uvIndex = weather_data[:hourly][:data][0][:uvIndex]
     @summaries = format_summary(weather_data)
     @time = weather_data[:currently][:time]
+    @hourly_forecast = hourly_group(weather_data)
+    @daily_forecast = daily_group(weather_data)
   end
 
   def format_time(weather_data)
@@ -51,5 +55,35 @@ class Forecast
 
   def tonight_sum
     summaries[:tonight_sum]
+  end
+
+  private
+
+  def hourly_group(weather_data)
+    hours = weather_data[:hourly][:data].first(8)
+    hours.each {|hash| hash[:time] = format_time_hourly(hash[:time])}
+  end
+
+  def format_time_hourly(time)
+    datetime = Time.at(time)
+    datetime.strftime('%l %p').strip
+  end
+
+  def daily_group(weather_data)
+    days = weather_data[:daily][:data].first(5)
+    days.each do |hash|
+      hash[:time] = format_time_daily(hash[:time])
+      hash[:precipProbability] = format_precip_prob(hash[:precipProbability])
+    end
+  end
+
+  def format_precip_prob(num)
+    percent = (num * 100).round(0)
+    "#{percent}%"
+  end
+
+  def format_time_daily(time)
+    datetime = Time.at(time)
+    datetime.strftime('%A')
   end
 end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,16 +1,34 @@
 class ForecastSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id,
-            :location,
-            :current_time,
-            :current_sum,
-            :icon,
-            :current_temp,
-            :temp_high,
-            :temp_low,
-            :feels_like,
-            :humidity,
-            :visibility,
-            :uvIndex,
-            :summaries
+  attribute :id
+
+  attribute :overview do |data|
+    {
+      location: data.location,
+      current_time: data.current_time,
+      current_summary: data.current_sum,
+      icon: data.icon,
+      temp: data.current_temp,
+      temp_high: data.temp_high,
+      temp_low: data.temp_low
+    }
+  end
+
+  attribute :details do |data|
+    {
+      feels_like: data.feels_like,
+      humidity: data.humidity,
+      visibility: data.visibility,
+      uvIndex: data.uvIndex,
+      summaries: data.summaries
+    }
+  end
+
+  attribute :hourly_forecast do |data|
+    data.hourly_forecast.map! {|hour| hour.slice(:time, :temperature)}
+  end
+
+  attribute :daily_forecast do |data|
+    data.daily_forecast.map! {|day| day.slice(:time, :summary, :precipProbability, :precipType, :temperatureHigh, :temperatureLow)}
+  end
 end

--- a/spec/models/forecast_spec.rb
+++ b/spec/models/forecast_spec.rb
@@ -2,58 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Forecast do
   before(:each) do
-    location_data = {
-      "results": [
-        "address_components": [
-          { "long_name": "Denver" },
-          { "long_name": "Denver County" },
-          { "short_name": "CO" },
-          { "long_name": "United States" }
-        ],
-        "geometry": {
-          "location": {
-             "lat": 39.7392358,
-             "lng": -104.990251
-          }
-        }
-      ]
-    }
+    geocoding_data = JSON.parse(stub_geocoding_request.response.body, symbolize_names: true)
+    location = Location.new(geocoding_data)
 
-    location = Location.new(location_data)
-
-    weather_data = {
-      :latitude => 39.7392358,
-      :longitude => -104.990251,
-      :currently => {
-        :time => 1572817477,
-        :summary=>"Mostly Cloudy",
-        :icon=>"partly-cloudy-day",
-        :temperature=>57.02
-      },
-      :daily => {
-        :data => [
-          :temperatureHigh => 56.39,
-          :temperatureLow => 27.73
-        ]
-      },
-      :hourly => {
-        :data => [
-          {
-            :time => 1572793200,  # Today
-            :summary => "Mostly cloudy until afternoon",
-            :apparentTemperature => 54.21,
-            :humidity => 0.29,
-            :visibility => 10,
-            :uvIndex => 1
-          },
-          {
-            :time => 1572814800,  # Tonight
-            :summary => "Partly cloudy starting tonight, continuing until tomorrow morning"
-          }
-        ]
-      }
-    }
-
+    weather_data = JSON.parse(stub_darksky_request.response.body, symbolize_names: true)
     @forecast = Forecast.new(location, weather_data)
   end
 
@@ -64,18 +16,20 @@ RSpec.describe Forecast do
   it "can return specific attributes" do
     expect(@forecast.id).to eq(0)
     expect(@forecast.location).to eq('Denver, CO, United States')
-    expect(@forecast.current_time).to eq('02:44 PM, 11/03')
-    expect(@forecast.current_sum).to eq('Mostly Cloudy')
+    expect(@forecast.current_time).to eq('03:55 PM, 11/02')
+    expect(@forecast.current_sum).to eq('Partly Cloudy')
     expect(@forecast.icon).to eq('partly-cloudy-day')
-    expect(@forecast.current_temp).to eq(57.02)
-    expect(@forecast.temp_high).to eq(56.39)
-    expect(@forecast.temp_low).to eq(27.73)
-    expect(@forecast.feels_like).to eq(54.21)
-    expect(@forecast.humidity).to eq(0.29)
+    expect(@forecast.current_temp).to eq(45.55)
+    expect(@forecast.temp_high).to eq(51.75)
+    expect(@forecast.temp_low).to eq(27.56)
+    expect(@forecast.feels_like).to eq(43.67)
+    expect(@forecast.humidity).to eq(0.41)
     expect(@forecast.visibility).to eq(10)
-    expect(@forecast.uvIndex).to eq(1)
-    expect(@forecast.today_sum).to eq('Mostly cloudy until afternoon')
-    expect(@forecast.tonight_sum).to eq('Partly cloudy starting tonight, continuing until tomorrow morning')
-    expect(@forecast.time).to eq(1572817477)
+    expect(@forecast.uvIndex).to eq(2)
+    expect(@forecast.today_sum).to eq('Partly Cloudy')
+    expect(@forecast.tonight_sum).to eq('Partly Cloudy')
+    expect(@forecast.time).to eq(1572731759)
+    expect(@forecast.hourly_forecast.count).to eq(8)
+    expect(@forecast.daily_forecast.count).to eq(5)
   end
 end

--- a/spec/requests/api/v1/forecast_spec.rb
+++ b/spec/requests/api/v1/forecast_spec.rb
@@ -13,7 +13,31 @@ describe 'Forecast API' do
 
     parsed = JSON.parse(response.body, symbolize_names: true)
 
-    expect(parsed[:data][:attributes][:location]).to eq("Denver, CO, United States")
-    expect(parsed[:data][:attributes].count).to eq(13)
+    expect(parsed[:data][:attributes].count).to eq(5)
+    expect(parsed[:data][:attributes][:overview]).to have_key(:location)
+    expect(parsed[:data][:attributes][:overview][:location]).to eq("Denver, CO, United States")
+    expect(parsed[:data][:attributes][:overview]).to have_key(:current_time)
+    expect(parsed[:data][:attributes][:overview]).to have_key(:current_summary)
+    expect(parsed[:data][:attributes][:overview]).to have_key(:icon)
+    expect(parsed[:data][:attributes][:overview]).to have_key(:temp)
+    expect(parsed[:data][:attributes][:overview]).to have_key(:temp_high)
+    expect(parsed[:data][:attributes][:overview]).to have_key(:temp_low)
+
+    expect(parsed[:data][:attributes][:details]).to have_key(:feels_like)
+    expect(parsed[:data][:attributes][:details]).to have_key(:humidity)
+    expect(parsed[:data][:attributes][:details]).to have_key(:visibility)
+    expect(parsed[:data][:attributes][:details]).to have_key(:uvIndex)
+    expect(parsed[:data][:attributes][:details]).to have_key(:summaries)
+
+    expect(parsed[:data][:attributes][:hourly_forecast].count).to eq(8)
+    expect(parsed[:data][:attributes][:hourly_forecast].first).to have_key(:time)
+    expect(parsed[:data][:attributes][:hourly_forecast].first).to have_key(:temperature)
+
+    expect(parsed[:data][:attributes][:daily_forecast].count).to eq(5)
+    expect(parsed[:data][:attributes][:daily_forecast].first).to have_key(:summary)
+    expect(parsed[:data][:attributes][:daily_forecast].first).to have_key(:precipProbability)
+    expect(parsed[:data][:attributes][:daily_forecast].first).to have_key(:precipType)
+    expect(parsed[:data][:attributes][:daily_forecast].first).to have_key(:temperatureHigh)
+    expect(parsed[:data][:attributes][:daily_forecast].first).to have_key(:temperatureLow)
   end
 end


### PR DESCRIPTION
- Refactor `ForecastSerializer` by making key-value pairs clear
- Add hourly and daily forecast data to json response hash
- Modify request spec accordingly